### PR TITLE
[PR] 메인 페이지 시작하기 버튼 수정

### DIFF
--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -100,7 +100,7 @@ export default function MainPage() {
               fontSize="xl"
               fontWeight="bold"
               p={6}
-              w={{ base: "full", lg: "auto" }}
+              w="full"
               _active={{ bg: "seed.active" }}
               _hover={{ bg: "seed.hover" }}
               onClick={() => navigate(ROUTE_PATHS.LOGIN)}

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -3,12 +3,27 @@ import { useNavigate } from "react-router";
 
 import { Box, Button, Flex, HStack, Text, VStack } from "@chakra-ui/react";
 
+import { useAuth } from "@/entities";
 import { AssignmentHelpSection, ExecutionOnlySection } from "@/features";
 import { CheckIcon, CopyIcon, ROUTE_PATHS, SparklesIcon } from "@/shared";
 
 export default function MainPage() {
   const [isSolutionSectionReady, setIsSolutionSectionReady] = useState(false);
   const navigate = useNavigate();
+  const { isAuthenticated, isLoading } = useAuth();
+
+  const startButtonTargetPath = isAuthenticated
+    ? ROUTE_PATHS.MYPAGE
+    : ROUTE_PATHS.LOGIN;
+  const isStartButtonDisabled = isLoading;
+
+  const handleStartClick = () => {
+    if (isStartButtonDisabled) {
+      return;
+    }
+
+    navigate(startButtonTargetPath);
+  };
 
   return (
     <Flex flexDir="column" align="center" bg="white">
@@ -97,13 +112,18 @@ export default function MainPage() {
               bg="button.bg"
               borderRadius={20}
               color="button.foreground"
+              cursor={isStartButtonDisabled ? "not-allowed" : "pointer"}
+              disabled={isStartButtonDisabled}
               fontSize="xl"
               fontWeight="bold"
+              opacity={isStartButtonDisabled ? 0.5 : 1}
               p={6}
               w="full"
               _active={{ bg: "seed.active" }}
-              _hover={{ bg: "seed.hover" }}
-              onClick={() => navigate(ROUTE_PATHS.LOGIN)}
+              _hover={{
+                bg: isStartButtonDisabled ? "button.bg" : "seed.hover",
+              }}
+              onClick={handleStartClick}
             >
               시작하기
             </Button>

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -12,17 +12,8 @@ export default function MainPage() {
   const navigate = useNavigate();
   const { isAuthenticated, isLoading } = useAuth();
 
-  const startButtonTargetPath = isAuthenticated
-    ? ROUTE_PATHS.MYPAGE
-    : ROUTE_PATHS.LOGIN;
-  const isStartButtonDisabled = isLoading;
-
   const handleStartClick = () => {
-    if (isStartButtonDisabled) {
-      return;
-    }
-
-    navigate(startButtonTargetPath);
+    navigate(isAuthenticated ? ROUTE_PATHS.MYPAGE : ROUTE_PATHS.LOGIN);
   };
 
   return (
@@ -112,17 +103,17 @@ export default function MainPage() {
               bg="button.bg"
               borderRadius={20}
               color="button.foreground"
-              cursor={isStartButtonDisabled ? "not-allowed" : "pointer"}
-              disabled={isStartButtonDisabled}
+              disabled={isLoading}
               fontSize="xl"
               fontWeight="bold"
-              opacity={isStartButtonDisabled ? 0.5 : 1}
               p={6}
               w="full"
               _active={{ bg: "seed.active" }}
-              _hover={{
-                bg: isStartButtonDisabled ? "button.bg" : "seed.hover",
+              _disabled={{
+                cursor: "not-allowed",
+                opacity: 0.5,
               }}
+              _hover={{ bg: "seed.hover" }}
               onClick={handleStartClick}
             >
               시작하기


### PR DESCRIPTION
## 📝 요약 (Summary)

- 메인 페이지의 `시작하기` 버튼이 로그인 상태에 따라 각각 `로그인 화면`과 `마이페이지`로 이동하도록 수정
- 데스크톱 환경에서도 버튼이 줄어들지 않도록 너비를 `w="full"`로 설정

## ✅ 주요 변경 사항 (Key Changes)

- `useAuth()`를 사용해 메인 CTA의 이동 경로를 각각 `/login` 과 `/mypage`로 분기했습니다.
- 인증 상태 확인 중 잘못된 이동을 방지하기 위해 버튼 비활성화 처리를 추가했습니다.
- 메인 페이지 `시작하기` 버튼의 너비를 `w="full"`로 변경했습니다.

## 💻 상세 구현 내용 (Implementation Details)

- 메인페이지에서 `useAuth()`의 `isAuthenticated`, `isLoading`을 사용하도록 변경했습니다.
- `handleStartClick` 내부에서 로그인 상태에 따라 목적 경로를 직접 분기하도록 정리했습니다.
- 로딩 중에는 `disabled`와 `_disabled`를 사용해서 버튼을 비활성화 처리해줬습니다. 

## 🚀 트러블 슈팅 (Trouble Shooting)

- 초기 렌더링 시 인증 상태가 동기화가 되지 않은 상태에서 로그인된 사용자가 `/login`으로 잘못 이동할 수 있었습니다.
=> 이를 방지하기 위해 `isLoading` 동안 CTA 버튼 상태를 비활성화되도록 처리했습니다.

## ⚠️ 알려진 이슈 및 참고 사항 (Known Issues & Notes)

- 다음 이슈에서 메인페이지의 시작하기 버튼 컴포넌트화를 포함한 리펙토링 진행하겠습니다.

## 📸 스크린샷 (Screenshots)
<img width="1094" height="379" alt="image" src="https://github.com/user-attachments/assets/3004db65-a695-4d1f-9f08-dad3e2e98355" />
<img width="1123" height="399" alt="image" src="https://github.com/user-attachments/assets/c8f733ab-dbf2-46da-910e-1c6d252f90ae" />


## #️⃣ 관련 이슈 (Related Issues)

- #69
