### PR TITLE
[PR] SEO 기본 설정 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "axios": "^1.13.4",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
+    "react-helmet-async": "^3.0.0",
     "react-router": "^7.13.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       react-dom:
         specifier: ^19.2.0
         version: 19.2.4(react@19.2.4)
+      react-helmet-async:
+        specifier: ^3.0.0
+        version: 3.0.0(react@19.2.4)
       react-router:
         specifier: ^7.13.0
         version: 7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1580,6 +1583,9 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
+  invariant@2.2.4:
+    resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
+
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
@@ -1974,6 +1980,14 @@ packages:
     peerDependencies:
       react: ^19.2.4
 
+  react-fast-compare@3.2.2:
+    resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
+
+  react-helmet-async@3.0.0:
+    resolution: {integrity: sha512-nA3IEZfXiclgrz4KLxAhqJqIfFDuvzQwlKwpdmzZIuC1KNSghDEIXmyU0TKtbM+NafnkICcwx8CECFrZ/sL/1w==}
+    peerDependencies:
+      react: ^16.6.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
@@ -2094,6 +2108,9 @@ packages:
 
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
+
+  shallowequal@1.1.0:
+    resolution: {integrity: sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -4335,6 +4352,10 @@ snapshots:
 
   inherits@2.0.4: {}
 
+  invariant@2.2.4:
+    dependencies:
+      loose-envify: 1.4.0
+
   is-arrayish@0.2.1: {}
 
   is-arrayish@0.3.4: {}
@@ -4683,6 +4704,15 @@ snapshots:
       react: 19.2.4
       scheduler: 0.27.0
 
+  react-fast-compare@3.2.2: {}
+
+  react-helmet-async@3.0.0(react@19.2.4):
+    dependencies:
+      invariant: 2.2.4
+      react: 19.2.4
+      react-fast-compare: 3.2.2
+      shallowequal: 1.1.0
+
   react-is@16.13.1: {}
 
   react-refresh@0.18.0: {}
@@ -4767,6 +4797,8 @@ snapshots:
   semver@7.7.3: {}
 
   set-cookie-parser@2.7.2: {}
+
+  shallowequal@1.1.0: {}
 
   shebang-command@2.0.0:
     dependencies:

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,7 @@
+User-agent: *
+Allow: /
+Disallow: /mypage
+Disallow: /upload
+Disallow: /project/
+
+Sitemap: https://www.seedlab.cloud/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://www.seedlab.cloud/</loc>
+  </url>
+</urlset>

--- a/src/app/providers/ApplicationProviders.tsx
+++ b/src/app/providers/ApplicationProviders.tsx
@@ -1,3 +1,5 @@
+import { HelmetProvider } from "react-helmet-async";
+
 import { Toaster } from "@/shared";
 
 import { AuthProvider, QueryProvider, ThemeProvider } from "./components";
@@ -8,13 +10,15 @@ type Props = {
 
 export const ApplicationProviders = ({ children }: Props) => {
   return (
-    <QueryProvider>
-      <AuthProvider>
-        <ThemeProvider>
-          {children}
-          <Toaster />
-        </ThemeProvider>
-      </AuthProvider>
-    </QueryProvider>
+    <HelmetProvider>
+      <QueryProvider>
+        <AuthProvider>
+          <ThemeProvider>
+            {children}
+            <Toaster />
+          </ThemeProvider>
+        </AuthProvider>
+      </QueryProvider>
+    </HelmetProvider>
   );
 };

--- a/src/pages/login/LoginPage.tsx
+++ b/src/pages/login/LoginPage.tsx
@@ -5,10 +5,12 @@ import {
   LoginHelpSection,
   LoginTitleText,
 } from "@/features";
+import { LOGIN_PAGE_SEO, Seo } from "@/shared";
 
 export default function LoginPage() {
   return (
     <Box bg="neutral.0" w="full">
+      <Seo config={LOGIN_PAGE_SEO} />
       <Flex
         direction="column"
         align="center"

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -5,7 +5,7 @@ import { Box, Button, Flex, HStack, Text, VStack } from "@chakra-ui/react";
 
 import { useAuth } from "@/entities";
 import { AssignmentHelpSection, ExecutionOnlySection } from "@/features";
-import { CheckIcon, CopyIcon, ROUTE_PATHS, SparklesIcon } from "@/shared";
+import { CheckIcon, CopyIcon, ROUTE_PATHS, Seo, SparklesIcon } from "@/shared";
 
 export default function MainPage() {
   const [isSolutionSectionReady, setIsSolutionSectionReady] = useState(false);
@@ -17,399 +17,403 @@ export default function MainPage() {
   };
 
   return (
-    <Flex flexDir="column" align="center" bg="white">
-      <Box
-        as="section"
-        display="flex"
-        minH="calc(100dvh - {sizes.headerHeight})"
-        w="full"
-      >
-        <Flex
-          align={{ base: "stretch", md: "center" }}
-          direction={{ base: "column", md: "row" }}
-          gap={{ base: 6, lg: 12 }}
-          justify={{ base: "center", lg: "space-between" }}
-          maxW="1200px"
-          mx="auto"
-          px={{ base: 6, lg: 10 }}
-          py={{ base: 16, md: 22, lg: 10 }}
+    <>
+      <Seo />
+      <Flex flexDir="column" align="center" bg="white">
+        <Box
+          as="section"
+          display="flex"
+          minH="calc(100dvh - {sizes.headerHeight})"
           w="full"
         >
-          <VStack
-            align="flex-start"
-            flex={{ base: "none", lg: 1 }}
-            gap={{ base: 3, lg: 6 }}
-            justify="center"
-            minW={0}
-          >
-            <HStack
-              bg={{ base: "none", lg: "container.bg.card" }}
-              borderRadius="full"
-              gap={2}
-              px={{ base: 0, lg: 4 }}
-              py={2}
-            >
-              <SparklesIcon boxSize={5} color="seed" />
-              <Text
-                color="text"
-                fontSize={{ base: "md", lg: "lg" }}
-                fontWeight="medium"
-              >
-                생산성 +50% 로켓 탑승하기
-              </Text>
-            </HStack>
-
-            <Text
-              color="text"
-              fontSize={{ base: "3xl", md: "5xl", lg: "7xl" }}
-              fontWeight="bold"
-              lineHeight="1.2"
-              textAlign="left"
-            >
-              오래 걸리는 과제,
-              <br />
-              <Box
-                as="span"
-                color="seed"
-                fontSize={{ base: "4xl", md: "6xl", lg: "7xl" }}
-              >
-                3단계로 압축하세요.
-              </Box>
-            </Text>
-
-            <Text
-              color="text.secondary"
-              fontSize={{ base: "md", lg: "lg" }}
-              fontWeight="medium"
-              textAlign="left"
-            >
-              PDF 업로드 한 번으로
-              <Box as="br" display={{ base: "block", lg: "none" }} />
-              <Box as="span" display={{ base: "none", lg: "inline" }}>
-                {" "}
-              </Box>
-              과제 로드맵부터 최적화 프롬프트까지.
-            </Text>
-          </VStack>
-
-          <VStack
-            align={{ base: "stretch", lg: "flex-start" }}
-            gap={4}
-            justify="center"
-            maxW="486px"
-            w="full"
-          >
-            <Button
-              bg="button.bg"
-              borderRadius={20}
-              color="button.foreground"
-              disabled={isLoading}
-              fontSize="xl"
-              fontWeight="bold"
-              p={6}
-              w="full"
-              _active={{ bg: "seed.active" }}
-              _disabled={{
-                cursor: "not-allowed",
-                opacity: 0.5,
-              }}
-              _hover={{ bg: "seed.hover" }}
-              onClick={handleStartClick}
-            >
-              시작하기
-            </Button>
-          </VStack>
-        </Flex>
-      </Box>
-      <AssignmentHelpSection
-        onSolutionReadyChange={setIsSolutionSectionReady}
-      />
-      <ExecutionOnlySection isActivated={isSolutionSectionReady} />
-      <Box bg="white" py={{ base: 20, md: 24, lg: 28 }} w="full">
-        <VStack
-          align="stretch"
-          gap={{ base: 10, lg: 14 }}
-          maxW="1200px"
-          mx="auto"
-          px={{ base: 4, lg: 10 }}
-          w="full"
-        >
-          <VStack
-            align="start"
-            gap={5}
-            maxW="780px"
-            w="full"
-            px={{ base: 4, xl: 0 }}
-          >
-            <Box
-              as="h2"
-              color="text"
-              fontSize={{ base: "2xl", md: "3xl", lg: "5xl" }}
-              fontWeight="bold"
-              lineHeight="1.4"
-            >
-              프롬프트 창 앞에서
-              <Box as="br" display={{ base: "block", md: "none" }} />
-              <Box
-                as="span"
-                color="seed"
-                fontSize={{ base: "3xl", md: "4xl", lg: "6xl" }}
-              >
-                {" "}
-                망설이지 마세요.
-              </Box>
-              <br />
-              정답은 이미
-              <Box as="br" display={{ base: "block", md: "none" }} />
-              <Box
-                as="span"
-                color="seed"
-                fontSize={{ base: "3xl", md: "4xl", lg: "6xl" }}
-              >
-                {" "}
-                SEED{" "}
-              </Box>
-              에 있습니다.
-            </Box>
-            <Box
-              as="p"
-              color="text.secondary"
-              fontSize={{ base: "md", lg: "xl" }}
-              fontWeight="medium"
-              lineHeight="1.4"
-            >
-              수만 개의 성공적인 프롬프트 데이터와
-              <Box as="br" display={{ base: "block", md: "none" }} /> 당신의
-              과제물의 분석을 통해
-              <br />각 로드맵에 최적화된 프롬프트를 제공합니다.
-            </Box>
-          </VStack>
-
           <Flex
             align={{ base: "stretch", md: "center" }}
-            justify="center"
             direction={{ base: "column", md: "row" }}
-            gap={{ base: 6, lg: 16 }}
-            px={{ base: 0, lg: 6 }}
-            py={{ base: 2, lg: 10 }}
+            gap={{ base: 6, lg: 12 }}
+            justify={{ base: "center", lg: "space-between" }}
+            maxW="1200px"
+            mx="auto"
+            px={{ base: 6, lg: 10 }}
+            py={{ base: 16, md: 22, lg: 10 }}
             w="full"
           >
-            <Box flex="1 1 0">
-              <Box
-                bg="container.bg"
-                border="1px solid"
-                borderColor="button.border.secondary"
-                borderRadius="4xl"
-                boxShadow="0px 20px 40px 0px rgba(0, 0, 0, 0.08)"
-                p={{ base: 4, lg: 8 }}
-                w="full"
-              >
-                <VStack align="stretch" gap={6} w="full">
-                  <Flex align="center" justify="space-between" w="full">
-                    <HStack align="center" gap={3}>
-                      <Flex
-                        align="center"
-                        bg="seed.subtle"
-                        borderRadius="full"
-                        boxSize={10}
-                        justify="center"
-                      >
-                        <SparklesIcon color="seed" boxSize={4.5} />
-                      </Flex>
-
-                      <VStack align="start" gap={0} minW={0}>
-                        <Text color="text" fontSize="sm" fontWeight="bold">
-                          Step 3 최적화 프롬프트
-                        </Text>
-                        <Text
-                          color="text.secondary"
-                          fontSize="xs"
-                          fontWeight="regular"
-                        >
-                          논문형
-                        </Text>
-                      </VStack>
-                    </HStack>
-
-                    <Button
-                      bg="button.bg"
-                      borderRadius="md"
-                      color="button.foreground"
-                      fontSize="xs"
-                      fontWeight="bold"
-                      h={8}
-                      minW="auto"
-                      px={3}
-                      py={2}
-                      type="button"
-                    >
-                      <HStack gap={1.5}>
-                        <CopyIcon color="white" boxSize={4.5} />
-                        <Text color="inherit" fontSize="xs" fontWeight="bold">
-                          Copy
-                        </Text>
-                      </HStack>
-                    </Button>
-                  </Flex>
-
-                  <Box
-                    bg="container.bg"
-                    border="1px solid"
-                    borderColor="neutral.50"
-                    borderRadius="xl"
-                    px={{ base: 2, lg: 5 }}
-                    py={4}
-                  >
-                    <Text
-                      color="text"
-                      fontFamily="'Courier New', monospace"
-                      fontSize="sm"
-                      gap={0}
-                      lineHeight="22.75px"
-                      w="full"
-                    >
-                      # Role: Academic Writer
-                      <br />
-                      # Task: Draft an assignment based on roadmap
-                      <br />
-                      <br />
-                      [Context]
-                      <br />
-                      Based on the previously summarized materials
-                      <br />
-                      regarding 'Inflation Impact', please draft a<br />
-                      comprehensive introduction. Include the
-                      <br />
-                      following key arguments: ...
-                      <br />
-                      <br />
-                      [Constraints]
-                      <br />
-                      - Use formal academic tone.
-                      <br />- Cite sources in APA format.
-                    </Text>
-                  </Box>
-                </VStack>
-              </Box>
-            </Box>
             <VStack
-              align="start"
-              gap={4}
-              maxW={{ base: "full", xl: "480px" }}
-              pt={{ base: 2, xl: 0 }}
-              px={{ base: 8, xl: 0 }}
-              w="auto"
+              align="flex-start"
+              flex={{ base: "none", lg: 1 }}
+              gap={{ base: 3, lg: 6 }}
+              justify="center"
+              minW={0}
             >
-              <Text
-                color="text"
-                fontSize={{ base: "2xl", md: "3xl", lg: "4xl" }}
-                fontWeight="bold"
-                lineHeight="1.25"
+              <HStack
+                bg={{ base: "none", lg: "container.bg.card" }}
+                borderRadius="full"
+                gap={2}
+                px={{ base: 0, lg: 4 }}
+                py={2}
               >
-                바로 복사해서
+                <SparklesIcon boxSize={5} color="seed" />
+                <Text
+                  color="text"
+                  fontSize={{ base: "md", lg: "lg" }}
+                  fontWeight="medium"
+                >
+                  생산성 +50% 로켓 탑승하기
+                </Text>
+              </HStack>
+
+              <Text
+                as="h1"
+                color="text"
+                fontSize={{ base: "3xl", md: "5xl", lg: "7xl" }}
+                fontWeight="bold"
+                lineHeight="1.2"
+                textAlign="left"
+              >
+                오래 걸리는 과제,
                 <br />
-                결과를 만들어보세요.
+                <Box
+                  as="span"
+                  color="seed"
+                  fontSize={{ base: "4xl", md: "6xl", lg: "7xl" }}
+                >
+                  3단계로 압축하세요.
+                </Box>
               </Text>
 
               <Text
                 color="text.secondary"
                 fontSize={{ base: "md", lg: "lg" }}
-                fontWeight="regular"
-                lineHeight="1.625"
-                maxW="420px"
+                fontWeight="medium"
+                textAlign="left"
               >
-                로드맵 각 단계에 꼭 맞는
+                PDF 업로드 한 번으로
                 <Box as="br" display={{ base: "block", lg: "none" }} />
-                최적의 프롬프트가 생성됩니다.
-                <br />
-                고민 없이 '복사' 버튼 하나면
-                <br />
-                전문적인 결과물로 이어질 수 있습니다.
+                <Box as="span" display={{ base: "none", lg: "inline" }}>
+                  {" "}
+                </Box>
+                과제 로드맵부터 최적화 프롬프트까지.
               </Text>
+            </VStack>
 
-              <VStack align="start" gap={4} pt={4}>
-                {[
-                  "단계별 맞춤형 프롬프트 제공",
-                  "원클릭 복사 및 재생성",
-                  "검증된 학술적 구조 적용",
-                ].map((feature) => {
-                  return (
-                    <HStack align="center" gap={3} key={feature} w="full">
-                      <Flex
-                        align="center"
-                        bg="seed.subtle"
-                        borderRadius="full"
-                        boxSize={6}
-                        justify="center"
-                      >
-                        <CheckIcon color="seed" boxSize={2.5} />
-                      </Flex>
-                      <Text
-                        color="text"
-                        fontSize="md"
-                        fontWeight="medium"
-                        lineHeight="24px"
-                      >
-                        {feature}
-                      </Text>
-                    </HStack>
-                  );
-                })}
-              </VStack>
+            <VStack
+              align={{ base: "stretch", lg: "flex-start" }}
+              gap={4}
+              justify="center"
+              maxW="486px"
+              w="full"
+            >
+              <Button
+                bg="button.bg"
+                borderRadius={20}
+                color="button.foreground"
+                disabled={isLoading}
+                fontSize="xl"
+                fontWeight="bold"
+                p={6}
+                w="full"
+                _active={{ bg: "seed.active" }}
+                _disabled={{
+                  cursor: "not-allowed",
+                  opacity: 0.5,
+                }}
+                _hover={{ bg: "seed.hover" }}
+                onClick={handleStartClick}
+              >
+                시작하기
+              </Button>
             </VStack>
           </Flex>
-        </VStack>
-      </Box>
-      <Box
-        alignItems="center"
-        as="section"
-        bg="white"
-        display="flex"
-        minH="100dvh"
-        justifyContent="center"
-        py={{ base: 16, md: 20, lg: 24 }}
-        w="full"
-      >
-        <VStack align="center" gap={{ base: 3, lg: 5 }} px={4} w="full">
-          <Text
-            color="text"
-            fontSize={{ base: "2xl", md: "3xl", lg: "5xl" }}
-            fontWeight="bold"
-            lineHeight="1.4"
-            textAlign="center"
+        </Box>
+        <AssignmentHelpSection
+          onSolutionReadyChange={setIsSolutionSectionReady}
+        />
+        <ExecutionOnlySection isActivated={isSolutionSectionReady} />
+        <Box bg="white" py={{ base: 20, md: 24, lg: 28 }} w="full">
+          <VStack
+            align="stretch"
+            gap={{ base: 10, lg: 14 }}
+            maxW="1200px"
+            mx="auto"
+            px={{ base: 4, lg: 10 }}
+            w="full"
           >
-            이제 과제는{" "}
-            <Box
-              as="span"
-              color="seed"
-              fontSize={{ base: "3xl", md: "4xl", lg: "6xl" }}
+            <VStack
+              align="start"
+              gap={5}
+              maxW="780px"
+              w="full"
+              px={{ base: 4, xl: 0 }}
             >
-              어떻게
-            </Box>
-            가 아니라
-            <br />
-            <Box
-              as="span"
-              color="seed"
-              fontSize={{ base: "3xl", md: "4xl", lg: "6xl" }}
+              <Box
+                as="h2"
+                color="text"
+                fontSize={{ base: "2xl", md: "3xl", lg: "5xl" }}
+                fontWeight="bold"
+                lineHeight="1.4"
+              >
+                프롬프트 창 앞에서
+                <Box as="br" display={{ base: "block", md: "none" }} />
+                <Box
+                  as="span"
+                  color="seed"
+                  fontSize={{ base: "3xl", md: "4xl", lg: "6xl" }}
+                >
+                  {" "}
+                  망설이지 마세요.
+                </Box>
+                <br />
+                정답은 이미
+                <Box as="br" display={{ base: "block", md: "none" }} />
+                <Box
+                  as="span"
+                  color="seed"
+                  fontSize={{ base: "3xl", md: "4xl", lg: "6xl" }}
+                >
+                  {" "}
+                  SEED{" "}
+                </Box>
+                에 있습니다.
+              </Box>
+              <Box
+                as="p"
+                color="text.secondary"
+                fontSize={{ base: "md", lg: "xl" }}
+                fontWeight="medium"
+                lineHeight="1.4"
+              >
+                수만 개의 성공적인 프롬프트 데이터와
+                <Box as="br" display={{ base: "block", md: "none" }} /> 당신의
+                과제물의 분석을 통해
+                <br />각 로드맵에 최적화된 프롬프트를 제공합니다.
+              </Box>
+            </VStack>
+
+            <Flex
+              align={{ base: "stretch", md: "center" }}
+              justify="center"
+              direction={{ base: "column", md: "row" }}
+              gap={{ base: 6, lg: 16 }}
+              px={{ base: 0, lg: 6 }}
+              py={{ base: 2, lg: 10 }}
+              w="full"
             >
-              무엇을{" "}
-            </Box>
-            할 지만 고민하세요.
-          </Text>
-          <Text
-            color="text.secondary"
-            fontSize={{ base: "md", lg: "xl" }}
-            fontWeight="medium"
-            lineHeight="1.4"
-            textAlign="center"
-          >
-            막막하던 과제의 시작부터 배경과 마무리까지,
-            <br />
-            SEED가 설계한 로드맵과 프롬프트가 함께 합니다.
-          </Text>
-        </VStack>
-      </Box>
-    </Flex>
+              <Box flex="1 1 0">
+                <Box
+                  bg="container.bg"
+                  border="1px solid"
+                  borderColor="button.border.secondary"
+                  borderRadius="4xl"
+                  boxShadow="0px 20px 40px 0px rgba(0, 0, 0, 0.08)"
+                  p={{ base: 4, lg: 8 }}
+                  w="full"
+                >
+                  <VStack align="stretch" gap={6} w="full">
+                    <Flex align="center" justify="space-between" w="full">
+                      <HStack align="center" gap={3}>
+                        <Flex
+                          align="center"
+                          bg="seed.subtle"
+                          borderRadius="full"
+                          boxSize={10}
+                          justify="center"
+                        >
+                          <SparklesIcon color="seed" boxSize={4.5} />
+                        </Flex>
+
+                        <VStack align="start" gap={0} minW={0}>
+                          <Text color="text" fontSize="sm" fontWeight="bold">
+                            Step 3 최적화 프롬프트
+                          </Text>
+                          <Text
+                            color="text.secondary"
+                            fontSize="xs"
+                            fontWeight="regular"
+                          >
+                            논문형
+                          </Text>
+                        </VStack>
+                      </HStack>
+
+                      <Button
+                        bg="button.bg"
+                        borderRadius="md"
+                        color="button.foreground"
+                        fontSize="xs"
+                        fontWeight="bold"
+                        h={8}
+                        minW="auto"
+                        px={3}
+                        py={2}
+                        type="button"
+                      >
+                        <HStack gap={1.5}>
+                          <CopyIcon color="white" boxSize={4.5} />
+                          <Text color="inherit" fontSize="xs" fontWeight="bold">
+                            Copy
+                          </Text>
+                        </HStack>
+                      </Button>
+                    </Flex>
+
+                    <Box
+                      bg="container.bg"
+                      border="1px solid"
+                      borderColor="neutral.50"
+                      borderRadius="xl"
+                      px={{ base: 2, lg: 5 }}
+                      py={4}
+                    >
+                      <Text
+                        color="text"
+                        fontFamily="'Courier New', monospace"
+                        fontSize="sm"
+                        gap={0}
+                        lineHeight="22.75px"
+                        w="full"
+                      >
+                        # Role: Academic Writer
+                        <br />
+                        # Task: Draft an assignment based on roadmap
+                        <br />
+                        <br />
+                        [Context]
+                        <br />
+                        Based on the previously summarized materials
+                        <br />
+                        regarding 'Inflation Impact', please draft a<br />
+                        comprehensive introduction. Include the
+                        <br />
+                        following key arguments: ...
+                        <br />
+                        <br />
+                        [Constraints]
+                        <br />
+                        - Use formal academic tone.
+                        <br />- Cite sources in APA format.
+                      </Text>
+                    </Box>
+                  </VStack>
+                </Box>
+              </Box>
+              <VStack
+                align="start"
+                gap={4}
+                maxW={{ base: "full", xl: "480px" }}
+                pt={{ base: 2, xl: 0 }}
+                px={{ base: 8, xl: 0 }}
+                w="auto"
+              >
+                <Text
+                  color="text"
+                  fontSize={{ base: "2xl", md: "3xl", lg: "4xl" }}
+                  fontWeight="bold"
+                  lineHeight="1.25"
+                >
+                  바로 복사해서
+                  <br />
+                  결과를 만들어보세요.
+                </Text>
+
+                <Text
+                  color="text.secondary"
+                  fontSize={{ base: "md", lg: "lg" }}
+                  fontWeight="regular"
+                  lineHeight="1.625"
+                  maxW="420px"
+                >
+                  로드맵 각 단계에 꼭 맞는
+                  <Box as="br" display={{ base: "block", lg: "none" }} />
+                  최적의 프롬프트가 생성됩니다.
+                  <br />
+                  고민 없이 '복사' 버튼 하나면
+                  <br />
+                  전문적인 결과물로 이어질 수 있습니다.
+                </Text>
+
+                <VStack align="start" gap={4} pt={4}>
+                  {[
+                    "단계별 맞춤형 프롬프트 제공",
+                    "원클릭 복사 및 재생성",
+                    "검증된 학술적 구조 적용",
+                  ].map((feature) => {
+                    return (
+                      <HStack align="center" gap={3} key={feature} w="full">
+                        <Flex
+                          align="center"
+                          bg="seed.subtle"
+                          borderRadius="full"
+                          boxSize={6}
+                          justify="center"
+                        >
+                          <CheckIcon color="seed" boxSize={2.5} />
+                        </Flex>
+                        <Text
+                          color="text"
+                          fontSize="md"
+                          fontWeight="medium"
+                          lineHeight="24px"
+                        >
+                          {feature}
+                        </Text>
+                      </HStack>
+                    );
+                  })}
+                </VStack>
+              </VStack>
+            </Flex>
+          </VStack>
+        </Box>
+        <Box
+          alignItems="center"
+          as="section"
+          bg="white"
+          display="flex"
+          minH="100dvh"
+          justifyContent="center"
+          py={{ base: 16, md: 20, lg: 24 }}
+          w="full"
+        >
+          <VStack align="center" gap={{ base: 3, lg: 5 }} px={4} w="full">
+            <Text
+              color="text"
+              fontSize={{ base: "2xl", md: "3xl", lg: "5xl" }}
+              fontWeight="bold"
+              lineHeight="1.4"
+              textAlign="center"
+            >
+              이제 과제는{" "}
+              <Box
+                as="span"
+                color="seed"
+                fontSize={{ base: "3xl", md: "4xl", lg: "6xl" }}
+              >
+                어떻게
+              </Box>
+              가 아니라
+              <br />
+              <Box
+                as="span"
+                color="seed"
+                fontSize={{ base: "3xl", md: "4xl", lg: "6xl" }}
+              >
+                무엇을{" "}
+              </Box>
+              할 지만 고민하세요.
+            </Text>
+            <Text
+              color="text.secondary"
+              fontSize={{ base: "md", lg: "xl" }}
+              fontWeight="medium"
+              lineHeight="1.4"
+              textAlign="center"
+            >
+              막막하던 과제의 시작부터 배경과 마무리까지,
+              <br />
+              SEED가 설계한 로드맵과 프롬프트가 함께 합니다.
+            </Text>
+          </VStack>
+        </Box>
+      </Flex>
+    </>
   );
 }

--- a/src/shared/components/features/Seo.tsx
+++ b/src/shared/components/features/Seo.tsx
@@ -1,0 +1,25 @@
+import { Helmet } from "react-helmet-async";
+
+import { DEFAULT_SEO, type SeoConfig } from "../../constants";
+
+const BASE_URL = "https://www.seedlab.cloud";
+
+type Props = {
+  config?: SeoConfig;
+};
+
+export const Seo = ({ config = DEFAULT_SEO }: Props) => (
+  <Helmet>
+    <title>{config.title}</title>
+    <meta name="description" content={config.description} />
+    {config.noindex && <meta name="robots" content="noindex,follow" />}
+    {config.path && <link rel="canonical" href={`${BASE_URL}${config.path}`} />}
+    <meta property="og:title" content={config.title} />
+    <meta property="og:description" content={config.description} />
+    {config.path && (
+      <meta property="og:url" content={`${BASE_URL}${config.path}`} />
+    )}
+    <meta name="twitter:title" content={config.title} />
+    <meta name="twitter:description" content={config.description} />
+  </Helmet>
+);

--- a/src/shared/components/features/index.ts
+++ b/src/shared/components/features/index.ts
@@ -1,2 +1,3 @@
 export * from "./CreateIcon";
+export * from "./Seo";
 export * from "./Toaster";

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -1,3 +1,4 @@
 export * from "./error-message";
 export * from "./route-path";
+export * from "./seo";
 export * from "./server-path";

--- a/src/shared/constants/seo.ts
+++ b/src/shared/constants/seo.ts
@@ -1,0 +1,19 @@
+export type SeoConfig = {
+  title: string;
+  description: string;
+  path?: string;
+  noindex?: boolean;
+};
+
+export const DEFAULT_SEO: SeoConfig = {
+  title: "과제 고민 끝, 대학생 맞춤형 AI 프롬프트 가이드 - SEED",
+  description:
+    "수만 개의 성공적인 프롬프트 데이터로 당신의 과제에 딱 맞는 로드맵을 제시합니다. 원클릭 복사로 논문, 레포트 등 완벽한 결과물을 만들어보세요.",
+  path: "/",
+};
+
+export const LOGIN_PAGE_SEO: SeoConfig = {
+  title: "로그인 - SEED",
+  description: "SEED에 로그인하세요.",
+  noindex: true,
+};

--- a/src/widgets/layout/components/footer/Footer.tsx
+++ b/src/widgets/layout/components/footer/Footer.tsx
@@ -18,13 +18,7 @@ export const Footer = () => {
           position="relative"
         >
           <Link to={ROUTE_PATHS.ROOT}>
-            <Image
-              src={Logo}
-              alt="Seed Logo"
-              h={6}
-              w="auto"
-              objectFit="contain"
-            />
+            <Image src={Logo} alt="SEED" h={6} w="auto" objectFit="contain" />
           </Link>
           <HStack
             display={{ base: "none", md: "flex" }}

--- a/src/widgets/layout/components/header/Header.tsx
+++ b/src/widgets/layout/components/header/Header.tsx
@@ -39,13 +39,7 @@ export const Header = () => {
         position="relative"
       >
         <Link to={ROUTE_PATHS.ROOT}>
-          <Image
-            src={Logo}
-            alt="Seed Logo"
-            h={8}
-            w="auto"
-            objectFit="contain"
-          />
+          <Image src={Logo} alt="SEED" h={8} w="auto" objectFit="contain" />
         </Link>
         {!isAuthenticated && (
           <HStack

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "rewrites": [
     {
-      "source": "/((?!favicon\\.ico|logo\\.webp|fonts/.*).*)",
+      "source": "/((?!favicon\\.ico|logo\\.webp|robots\\.txt|sitemap\\.xml|google.*\\.html|fonts/.*).*)",
       "destination": "/index.html"
     }
   ]


### PR DESCRIPTION
## 📝 요약 (Summary)

Google 검색 결과에서 홈 제목이 의도한 메타 대신 `Seed Logo`로 보이는 문제가 있어서 SEO 기본 구조를 정리했습니다.
페이지별 메타 관리, 로그인 페이지 `noindex`, `robots.txt`/`sitemap.xml` 추가해줬습니다.

## ✅ 주요 변경 사항 (Key Changes)

- `react-helmet-async` 기반으로 페이지별 SEO 메타 관리 구조 추가
- 메인 페이지 SEO 적용 및 로그인 페이지 `noindex,follow` 처리
- `robots.txt`, `sitemap.xml` 추가
- 메인 대표 문구를 `h1`로 변경하고 로고 `alt` 문구를 `SEED`로 정리

## 💻 상세 구현 내용 (Implementation Details)

### 1. 페이지별 SEO 메타 관리 구조 추가

기존에는 `index.html`의 정적 메타만 설정해줬습니다.
`react-helmet-async`를 적용해서 `MainPage`, `LoginPage`에서 각각 필요한 `title`, `description`, `canonical`, `robots`를 제어할 수 있도록 변경했습니다.

- `ApplicationProviders`에 `HelmetProvider` 추가
- `Seo` 공용 컴포넌트 추가
- `DEFAULT_SEO`, `LOGIN_PAGE_SEO` 상수 분리

### 2. 로그인 페이지는 `robots.txt`가 아니라 `noindex`로 처리

Google 공식 문서에 따르면 `robots.txt`는 크롤링을 제어하는 용도이지, 검색 결과에서 페이지를 반드시 제외하는 용도는 아닙니다.  
그래서 `/login`은 `robots.txt` 차단 대신에 메타 태그 `noindex,follow`를 적용해서 "검색 결과에는 안 나오는데 굳이 해당 페이지에 있는 다른 링크들을 숨기지는 않겠다" 정도로 설정했습니다.

참고:
- [robots.txt 소개](https://developers.google.com/search/docs/crawling-indexing/robots/intro?hl=ko)
  
### 3. `robots.txt`와 `sitemap.xml` 추가

`robots.txt`에는 인증이 필요한 경로(`/mypage`, `/upload`, `/project/`)를 크롤링을 권장하지 않는 경로로 추가했습니다.  
```txt
// robots.txt
User-agent: *
Allow: /
Disallow: /mypage
Disallow: /upload
Disallow: /project/

Sitemap: https://www.seedlab.cloud/sitemap.xml
```
이 경로들은 실제로 `ProtectedRoute`로 보호되고 있어서 검색 엔진이 굳이 볼 이유가 없다고 판단했습니다.

`sitemap.xml`은 홈(`/`) URL만 남긴 최소 형태로 구성했습니다.  
```xml
// sitemap.xml
<?xml version="1.0" encoding="UTF-8"?>
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
  <url>
    <loc>https://www.seedlab.cloud/</loc>
  </url>
</urlset>

```
Google 공식 문서 기준으로 sitemap은 "검색 결과에 표시하려는 canonical URL"을 알려주는 역할에 가깝고, 사실상 우리 사이트의 홈 화면만 공개 SEO 대상이라 위와 같이 진행했습니다.

또한 같은 문서에서 Google은 `<priority>`와 `<changefreq>`를 무시한다고 안내하고 있고, `<lastmod>`는 정확하고 일관되게 유지할 수 있을 때만 사용하는 것을 권장하고 있어 이번에는 단순한 형태로 유지했습니다.

참고:
- [사이트맵 제작 및 제출하기](https://developers.google.com/search/docs/crawling-indexing/sitemaps/build-sitemap?hl=ko)
  
### 4. 검색 결과 재작성 완화를 위한 문서 신호 보완

검색 결과에서 제목이 `Seed Logo`로 보이던 현상을 줄이기 위해 문서 구조도 함께 정리했습니다.

- 메인 페이지 핵심 헤드카피를 `h1`로 지정
- 헤더/푸터 로고 `alt`를 `Seed Logo`에서 `SEED`로 수정

## 🚀 트러블 슈팅 (Trouble Shooting)
해당 없음

## ⚠️ 알려진 이슈 및 참고 사항 (Known Issues & Notes)

- 검색 결과 반영은 Google 재크롤링 시점에 따라 바로 보이지 않을 수 있습니다.
- ProtectedRoute 대상 페이지는 현재 SEO 적용 대상에서 제외했습니다.

## 📸 스크린샷 (Screenshots)

- 수정되고나서 배포 된 상태에서 확인 후 스크린샷 올리겠습니다.

## #️⃣ 관련 이슈 (Related Issues)

- #71
