### PR TITLE
[PR] 과제 업로드 페이지(UploadPage) 모바일 반응형 UI 설정

### DIFF
--- a/src/features/upload/components/features/upload-page/UploadFileDropzone.tsx
+++ b/src/features/upload/components/features/upload-page/UploadFileDropzone.tsx
@@ -1,6 +1,6 @@
 import type { ChangeEvent, DragEvent, RefObject } from "react";
 
-import { Flex, Text, VStack } from "@chakra-ui/react";
+import { Box, Flex, Text, VStack } from "@chakra-ui/react";
 
 import { FilePdfIcon } from "@/shared";
 
@@ -43,10 +43,10 @@ export const UploadFileDropzone = ({
         cursor="pointer"
         direction="column"
         flex={1}
-        gap={3}
+        gap={{ base: 2.5, md: 3 }}
         justify="center"
-        minH="200px"
-        p={6}
+        minH={{ base: "160px", md: "200px" }}
+        p={{ base: 5, md: 6 }}
         transition="border-color 0.15s"
         onClick={() => fileInputRef.current?.click()}
         onDragLeave={onDragLeave}
@@ -57,10 +57,10 @@ export const UploadFileDropzone = ({
           align="center"
           bg="white"
           borderRadius="full"
-          boxSize={12}
+          boxSize={{ base: 10, md: 12 }}
           justify="center"
         >
-          <Text color="neutral.600" fontSize="2xl">
+          <Text color="neutral.600" fontSize={{ base: "xl", md: "2xl" }}>
             +
           </Text>
         </Flex>
@@ -71,10 +71,20 @@ export const UploadFileDropzone = ({
             fontWeight="bold"
             textAlign="center"
           >
-            파일을 드래그해보세요
+            <Box as="span" display={{ base: "inline", md: "none" }}>
+              파일을 선택해보세요
+            </Box>
+            <Box as="span" display={{ base: "none", md: "inline" }}>
+              파일을 드래그해보세요
+            </Box>
           </Text>
           <Text color="neutral.600" fontSize="xs" textAlign="center">
-            또는 클릭하여 업로드
+            <Box as="span" display={{ base: "inline", md: "none" }}>
+              탭해서 업로드
+            </Box>
+            <Box as="span" display={{ base: "none", md: "inline" }}>
+              또는 클릭해서 업로드
+            </Box>
           </Text>
         </VStack>
         <Flex
@@ -82,7 +92,7 @@ export const UploadFileDropzone = ({
           bg="white"
           borderRadius="full"
           gap={1}
-          px={3}
+          px={{ base: 2.5, md: 3 }}
           py={1}
         >
           <FilePdfIcon boxSize="10px" color="neutral.600" />

--- a/src/features/upload/components/features/upload-page/UploadFileItem.tsx
+++ b/src/features/upload/components/features/upload-page/UploadFileItem.tsx
@@ -61,8 +61,8 @@ export const UploadFileItem = ({ file, onRemove }: Props) => {
       bg="white"
       borderRadius="xl"
       boxShadow="0px 2px 8px 0px rgba(0,0,0,0.06)"
-      gap={3}
-      p={3}
+      gap={{ base: 2.5, md: 3 }}
+      p={{ base: 2.5, md: 3 }}
     >
       <UploadFileIcon file={file} />
       <VStack align="flex-start" flex={1} gap={0} minW={0}>

--- a/src/features/upload/components/features/upload-page/UploadFileList.tsx
+++ b/src/features/upload/components/features/upload-page/UploadFileList.tsx
@@ -25,7 +25,7 @@ export const UploadFileList = ({
   onRemoveFile,
 }: Props) => {
   return (
-    <VStack align="stretch" flex={1} gap={3} justify="space-between">
+    <VStack align="stretch" flex={1} gap={3} justify="space-between" w="full">
       <VStack align="stretch" gap={2}>
         {uploadedFiles.map(({ id, file }) => (
           <UploadFileItem
@@ -51,7 +51,7 @@ export const UploadFileList = ({
               cursor="pointer"
               gap={2}
               justify="center"
-              py={2}
+              py={{ base: 3, md: 2 }}
               transition="color 0.15s"
               _hover={{ color: "seed" }}
               onClick={() => addFileInputRef.current?.click()}

--- a/src/features/upload/ui/section/UploadAssignmentTypeSection.tsx
+++ b/src/features/upload/ui/section/UploadAssignmentTypeSection.tsx
@@ -1,4 +1,4 @@
-import { Flex, Text, VStack } from "@chakra-ui/react";
+import { Button, Flex, Text, VStack } from "@chakra-ui/react";
 
 import { type AssignmentType } from "@/entities";
 
@@ -23,10 +23,9 @@ export const UploadAssignmentTypeSection = ({
           const isActive = selectedType === label;
 
           return (
-            <Flex
-              as="button"
+            <Button
+              aria-pressed={isActive}
               key={label}
-              align="center"
               bg={isActive ? "seed.subtle" : "neutral.50"}
               border="2px solid"
               borderColor={isActive ? "seed" : "neutral.50"}
@@ -34,10 +33,16 @@ export const UploadAssignmentTypeSection = ({
               cursor="pointer"
               gap={2}
               h={{ base: 12, md: 14 }}
-              justify="center"
               minW={{ base: "calc(50% - 4px)", md: "120px" }}
               px={{ base: 3, md: 5 }}
               transition="all 0.15s"
+              type="button"
+              variant="plain"
+              _focusVisible={{
+                outline: "2px solid",
+                outlineColor: "seed",
+                outlineOffset: "2px",
+              }}
               onClick={() => onSelectType(label)}
             >
               <Icon boxSize="15px" color={isActive ? "seed" : "neutral.900"} />
@@ -49,7 +54,7 @@ export const UploadAssignmentTypeSection = ({
               >
                 {label}
               </Text>
-            </Flex>
+            </Button>
           );
         })}
       </Flex>

--- a/src/features/upload/ui/section/UploadAssignmentTypeSection.tsx
+++ b/src/features/upload/ui/section/UploadAssignmentTypeSection.tsx
@@ -1,4 +1,4 @@
-import { Flex, HStack, Text, VStack } from "@chakra-ui/react";
+import { Flex, Text, VStack } from "@chakra-ui/react";
 
 import { type AssignmentType } from "@/entities";
 
@@ -18,12 +18,13 @@ export const UploadAssignmentTypeSection = ({
       <Text color="neutral.600" fontSize="sm" fontWeight="semibold">
         과제 유형
       </Text>
-      <HStack flexWrap="wrap" gap={3}>
+      <Flex gap={{ base: 2, md: 3 }} wrap="wrap" w="full">
         {UPLOAD_ASSIGNMENT_TYPES.map(({ label, Icon }) => {
           const isActive = selectedType === label;
 
           return (
             <Flex
+              as="button"
               key={label}
               align="center"
               bg={isActive ? "seed.subtle" : "neutral.50"}
@@ -32,10 +33,10 @@ export const UploadAssignmentTypeSection = ({
               borderRadius="3xl"
               cursor="pointer"
               gap={2}
-              h={14}
+              h={{ base: 12, md: 14 }}
               justify="center"
-              minW="120px"
-              px={5}
+              minW={{ base: "calc(50% - 4px)", md: "120px" }}
+              px={{ base: 3, md: 5 }}
               transition="all 0.15s"
               onClick={() => onSelectType(label)}
             >
@@ -51,7 +52,7 @@ export const UploadAssignmentTypeSection = ({
             </Flex>
           );
         })}
-      </HStack>
+      </Flex>
     </VStack>
   );
 };

--- a/src/features/upload/ui/section/UploadContentAndFileSection.tsx
+++ b/src/features/upload/ui/section/UploadContentAndFileSection.tsx
@@ -48,27 +48,35 @@ export const UploadContentAndFileSection = ({
       </Text>
 
       <Flex
+        direction={{ base: "column", md: "row" }}
         border="1px solid"
         borderColor="neutral.50"
-        borderRadius="4xl"
+        borderRadius={{ base: "3xl", md: "4xl" }}
         boxShadow="0px 4px 20px 0px rgba(0,0,0,0.02)"
         overflow="hidden"
         w="full"
       >
-        <Flex bg="white" direction="column" flex={1} p={8}>
+        <Flex bg="white" direction="column" flex={1} p={{ base: 4, md: 8 }}>
           <Textarea
             border="none"
             color="neutral.900"
             flex={1}
-            h={64}
+            fontSize={{ base: "sm", md: "md" }}
+            lineHeight="1.6"
             maxLength={maxContentLength}
+            minH={{ base: "320px", md: "256px" }}
             placeholder={
               "교수님이 제시한 과제 주제나 요구사항을 자유롭게 적어주세요.\n예: '마케팅 전략 분석 리포트 작성, 2000자 이내, SWOT 분석 포함 필수'"
             }
             resize="none"
             value={content}
             _focusVisible={{ outline: "none", boxShadow: "none" }}
-            _placeholder={{ color: "neutral.300" }}
+            _placeholder={{
+              color: "neutral.300",
+              lineHeight: "1.6",
+              whiteSpace: "pre-wrap",
+              wordBreak: "keep-all",
+            }}
             onChange={(e) => onContentChange(e.target.value)}
           />
           <Flex
@@ -76,7 +84,7 @@ export const UploadContentAndFileSection = ({
             borderTop="1px solid"
             borderColor="neutral.50"
             justify="space-between"
-            pt={4}
+            pt={{ base: 3, md: 4 }}
           >
             <Box bg="neutral.50" borderRadius="md" px={2} py={1}>
               <Text color="neutral.600" fontSize="xs" fontWeight="medium">
@@ -92,12 +100,14 @@ export const UploadContentAndFileSection = ({
         <Flex
           bg="neutral.50"
           borderColor="neutral.50"
+          borderLeftWidth={{ base: "0px", md: "1px" }}
+          borderTopWidth={{ base: "1px", md: "0px" }}
           direction="column"
           flexShrink={0}
           justify="center"
-          minH="377px"
-          p={8}
-          w={80}
+          minH={{ base: "auto", md: "377px" }}
+          p={{ base: 4, md: 8 }}
+          w={{ base: "full", md: 80 }}
         >
           {uploadedFiles.length === 0 ? (
             <UploadFileDropzone

--- a/src/features/upload/ui/section/UploadSubmitSection.tsx
+++ b/src/features/upload/ui/section/UploadSubmitSection.tsx
@@ -1,4 +1,4 @@
-import { Flex, Text } from "@chakra-ui/react";
+import { Button, Flex, Text } from "@chakra-ui/react";
 
 type Props = {
   canSubmit: boolean;
@@ -16,28 +16,35 @@ export const UploadSubmitSection = ({
   const isDisabled = !canSubmit || isPending;
 
   return (
-    <Flex align="center" direction="column" gap={6}>
-      <Flex
-        align="center"
+    <Flex align="center" direction="column" gap={{ base: 4, md: 6 }} w="full">
+      <Button
         bg="seed"
         borderRadius="2xl"
         boxShadow="0px 8px 20px 0px rgba(152,201,92,0.25)"
-        cursor={isDisabled ? "not-allowed" : "pointer"}
-        gap={2}
-        h={14}
-        justify="center"
-        maxW={96}
+        color="white"
+        disabled={isDisabled}
+        fontSize={{ base: "sm", md: "md" }}
+        fontWeight="bold"
+        h={{ base: 12, md: 14 }}
+        maxW={{ base: "full", md: "384px" }}
         opacity={isDisabled ? 0.5 : 1}
-        px={8}
-        transition="opacity 0.15s"
+        px={{ base: 6, md: 8 }}
+        transition="opacity 0.15s, background-color 0.15s"
         w="full"
-        _hover={{ opacity: isDisabled ? 0.5 : 0.85 }}
+        whiteSpace="normal"
+        _disabled={{ bg: "seed", cursor: "not-allowed", opacity: 0.5 }}
+        _hover={{ bg: "seed.hover" }}
         onClick={onSubmit}
       >
-        <Text color="white" fontWeight="bold">
+        <Text
+          color="white"
+          fontWeight="bold"
+          lineHeight="1.3"
+          textAlign="center"
+        >
           {stepCount}단계 로드맵 생성하기 →
         </Text>
-      </Flex>
+      </Button>
       <Text color="neutral.600" fontSize="xs" textAlign="center">
         작성하신 내용은 로드맵 생성 및 추천에만 사용됩니다.
       </Text>

--- a/src/features/upload/ui/section/UploadSubmitSection.tsx
+++ b/src/features/upload/ui/section/UploadSubmitSection.tsx
@@ -27,7 +27,6 @@ export const UploadSubmitSection = ({
         fontWeight="bold"
         h={{ base: 12, md: 14 }}
         maxW={{ base: "full", md: "384px" }}
-        opacity={isDisabled ? 0.5 : 1}
         px={{ base: 6, md: 8 }}
         transition="opacity 0.15s, background-color 0.15s"
         w="full"

--- a/src/features/upload/ui/section/UploadTitleSection.tsx
+++ b/src/features/upload/ui/section/UploadTitleSection.tsx
@@ -7,13 +7,15 @@ type Props = {
 
 export const UploadTitleSection = ({ title, onChange }: Props) => {
   return (
-    <Box maxW="768px" w="full">
+    <Box maxW={{ base: "full", md: "768px" }} w="full">
       <Input
         border="none"
         color={title ? "neutral.900" : "neutral.300"}
-        fontSize="4xl"
+        fontSize={{ base: "2xl", md: "4xl" }}
         fontWeight="bold"
+        minH={{ base: "56px", md: "auto" }}
         placeholder="프로젝트 제목을 입력하세요"
+        py={{ base: 2, md: 0 }}
         textAlign="center"
         value={title}
         _focusVisible={{ outline: "none", boxShadow: "none" }}

--- a/src/pages/upload/UploadPage.tsx
+++ b/src/pages/upload/UploadPage.tsx
@@ -33,11 +33,11 @@ export default function UploadPage() {
 
         <Flex
           bg="white"
-          borderRadius="4xl"
+          borderRadius={{ base: "3xl", md: "4xl" }}
           boxShadow="0px 20px 60px -10px rgba(0,0,0,0.08)"
           direction="column"
-          gap={12}
-          p={12}
+          gap={{ base: 8, md: 12 }}
+          p={{ base: 4, md: 8, lg: 12 }}
           w="full"
         >
           <UploadAssignmentTypeSection

--- a/src/pages/upload/UploadPage.tsx
+++ b/src/pages/upload/UploadPage.tsx
@@ -23,10 +23,10 @@ export default function UploadPage() {
       <Flex
         align="center"
         direction="column"
-        gap={12}
+        gap={{ base: 8, md: 12 }}
         maxW="1024px"
-        px={6}
-        py={20}
+        px={{ base: 4, md: 6 }}
+        py={{ base: 8, md: 14, lg: 20 }}
         w="full"
       >
         <UploadTitleSection title={fields.title} onChange={fields.setTitle} />

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -25,7 +25,6 @@
     "noUncheckedSideEffectImports": true,
 
     /* alias */
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,6 @@
     { "path": "./tsconfig.node.json" }
   ],
   "compilerOptions": {
-    "baseUrl": ".",
     "jsxImportSource": "@emotion/react",
     "paths": {
       "@/*": ["./src/*"]


### PR DESCRIPTION
## 📝 요약 (Summary)

- 업로드 페이지가 모바일 화면에서 깨져 보이던 부분을 정리했습니다.
-  작은 화면에서도 제목 입력, 과제 유형 선택, 내용 작성, 파일 업로드, 제출 버튼이 자연스럽게 보이도록 했습니다.

## ✅ 주요 변경 사항 (Key Changes)

- 업로드 페이지 전체 여백과 카드 간격을 모바일 화면에 맞게 조정했습니다.
- 내용 작성 영역과 파일 업로드 영역이 모바일에서는 위아래 배치로 변경했습니다.
- 제출 버튼을 모바일에서도 보기 좋게 정리했습니다.

## 💻 상세 구현 내용 (Implementation Details)

### 1. 업로드 페이지 상단 레이아웃 정리
<img width="412" height="115" alt="image" src="https://github.com/user-attachments/assets/befceb4e-d9d8-474f-8654-39b75664d8d0" />

- 페이지 바깥 여백과 내부 카드 여백을 화면 크기에 따라 다르게 보이도록 수정했습니다.
- 제목 입력 영역의 크기와 높이를 조정해 모바일에서도 답답하지 않게 보이도록 했습니다.

### 2. 과제 유형 선택 영역 반응형 적용
<img width="411" height="221" alt="image" src="https://github.com/user-attachments/assets/4cdae3c6-0c68-4fe6-a3bb-6311dd7606ae" />

- 모바일에서는 과제 유형 버튼이 한 줄에 몰리지 않도록 정리했습니다.
- 작은 화면에서도 버튼이 눌리기 쉽게 간격과 크기를 조정했습니다.

### 3. 내용 작성 / 파일 업로드 영역 개선
<img width="381" height="654" alt="image" src="https://github.com/user-attachments/assets/f4560a56-d738-4735-b79b-ee53d483d409" />

- 데스크톱에서는 기존처럼 좌우 배치를 유지하고, 모바일에서는 위아래 배치로 바꿨습니다.
- 내용 입력 영역은 모바일에서 placeholder가 잘리지 않도록 최소 높이와 줄바꿈을 조정했습니다.
- 파일 드롭존은 모바일 환경에 맞게 문구를 바꿔, 드래그 대신 파일 선택/탭 업로드 중심으로 보이게 했습니다.
- 파일 목록과 파일 아이템 간격도 모바일에 맞게 정리했습니다.

### 4. 제출 영역 정리
<img width="394" height="123" alt="image" src="https://github.com/user-attachments/assets/a0190899-1bcd-4308-b8db-9614dcf204fc" />

- 제출 영역의 클릭 박스를 실제 버튼으로 바꿔 더 자연스럽게 동작하도록 수정했습니다.
- 모바일에서는 버튼이 전체 너비로 보이도록 조정했습니다.
- 단위는 일관되게 `px` 기준으로 맞췄습니다.

## 🚀 트러블 슈팅 (Trouble Shooting)

- 해당 없음

## ⚠️ 알려진 이슈 및 참고 사항 (Known Issues & Notes)

- 다음 이슈에서 업로드 로딩 페이지와 단계 페이지도 반응형 ui 설정 추가해주겠습니다.

## 📸 스크린샷 (Screenshots)
<img width="412" height="1217" alt="image" src="https://github.com/user-attachments/assets/e5181bd8-f9e9-409d-bb3a-a4c8b3f8247d" />


## #️⃣ 관련 이슈 (Related Issues)

- #73 
