### PR TITLE
[PR] 과제 업로드 완료 페이지(UploadCompletePage) 모바일 반응형 UI 설정 및 사용자 입력값 ui 추가

### DIFF
--- a/src/pages/upload/_complete/UploadCompletePage.tsx
+++ b/src/pages/upload/_complete/UploadCompletePage.tsx
@@ -3,13 +3,9 @@ import { useNavigate, useParams } from "react-router";
 
 import { Box, Button, Flex, HStack, Text, VStack } from "@chakra-ui/react";
 
-import { useGetProjectDetail } from "@/entities";
+import { PromptCard, useGetProjectDetail } from "@/entities";
 import { ROUTE_PATHS, toaster } from "@/shared";
-import {
-  CheckCircleIcon,
-  ChevronRightIcon,
-  CopyIcon,
-} from "@/shared/_assets/icons";
+import { CheckCircleIcon, ChevronRightIcon } from "@/shared/_assets/icons";
 
 type Asset = {
   id: number;
@@ -28,6 +24,7 @@ function AssetItem({
 }) {
   const [open, setOpen] = useState(defaultOpen ?? false);
   const [copiedPrompt, setCopiedPrompt] = useState(false);
+  const [copiedResult, setCopiedResult] = useState(false);
 
   const copy = (text: string, setter: (v: boolean) => void) => {
     if (!navigator?.clipboard?.writeText) {
@@ -38,6 +35,7 @@ function AssetItem({
       });
       return;
     }
+
     navigator.clipboard
       .writeText(text)
       .then(() => {
@@ -75,8 +73,8 @@ function AssetItem({
             align="center"
             bg="neutral.50"
             borderRadius="12px"
-            flexShrink={0}
             boxSize={{ base: 8, md: 10 }}
+            flexShrink={0}
             justify="center"
           >
             <Text
@@ -87,6 +85,7 @@ function AssetItem({
               {asset.id}
             </Text>
           </Flex>
+
           <VStack align="flex-start" gap={0.5}>
             <Text
               color="neutral.900"
@@ -102,6 +101,7 @@ function AssetItem({
             </Text>
           </VStack>
         </HStack>
+
         <Box
           style={{
             transform: open ? "rotate(270deg)" : "rotate(90deg)",
@@ -113,85 +113,28 @@ function AssetItem({
       </Flex>
 
       {open && (
-        <VStack align="flex-start" gap="10px" pb="17px" px={5}>
-          <Box
-            bg="neutral.50"
-            border="1px solid"
-            borderColor="neutral.50"
-            borderRadius="xl"
-            p={5}
-            w="full"
-          >
-            <Flex align="center" justify="space-between" mb={2}>
-              <Text color="neutral.600" fontSize="xs" fontWeight="semibold">
-                생성된 프롬프트
-              </Text>
-              <Button
-                color={copiedPrompt ? "seed" : "neutral.600"}
-                fontSize="xs"
-                fontWeight="bold"
-                gap={1.5}
-                onClick={() => copy(asset.prompt, setCopiedPrompt)}
-                px={2}
-                py={1.5}
-                size="xs"
-                variant="ghost"
-              >
-                <CopyIcon boxSize={3} />
-                {copiedPrompt ? "복사됨 ✓" : "복사하기"}
-              </Button>
-            </Flex>
-            <Text
-              as="pre"
-              color="neutral.900"
-              fontFamily="mono"
-              fontSize="xs"
-              lineHeight="1.4"
-              whiteSpace="pre-wrap"
-            >
-              {asset.prompt}
-            </Text>
-          </Box>
+        <VStack
+          align="flex-start"
+          gap={{ base: 3, md: "10px" }}
+          pb={{ base: 4, md: "17px" }}
+          px={{ base: 4, md: 5 }}
+          w="full"
+        >
+          <PromptCard
+            content={asset.prompt}
+            copied={copiedPrompt}
+            label="생성된 프롬프트"
+            onCopy={() => copy(asset.prompt, setCopiedPrompt)}
+          />
 
-          {/* <Box
-            bg="neutral.50"
-            border="1px solid"
-            borderColor="neutral.50"
-            borderRadius="xl"
-            p={5}
-            w="full"
-          >
-            <Flex align="center" justify="space-between" mb={2}>
-              <Text color="neutral.600" fontSize="xs" fontWeight="semibold">
-                Prompt Result
-              </Text>
-              {asset.result && (
-                <Button
-                  color="seed"
-                  fontSize="xs"
-                  fontWeight="bold"
-                  gap={1.5}
-                  onClick={() => copy(asset.result, setCopiedResult)}
-                  px={2}
-                  py={1.5}
-                  size="xs"
-                  variant="ghost"
-                >
-                  <CopyIcon boxSize={3} />
-                  {copiedResult ? "복사됨 ✓" : "복사하기"}
-                </Button>
-              )}
-            </Flex>
-            {asset.result ? (
-              <Text color="neutral.900" fontSize="sm" lineHeight="1.4">
-                {asset.result}
-              </Text>
-            ) : (
-              <Text color="neutral.600" fontSize="sm">
-                결과가 입력되지 않았습니다.
-              </Text>
-            )}
-          </Box> */}
+          {asset.result && (
+            <PromptCard
+              content={asset.result}
+              copied={copiedResult}
+              label="작업 결과"
+              onCopy={() => copy(asset.result, setCopiedResult)}
+            />
+          )}
         </VStack>
       )}
     </Box>
@@ -222,7 +165,7 @@ export default function UploadCompletePage() {
       title: step.stepName,
       subtitle: step.stepCode,
       prompt: step.providedPromptSnapshot,
-      result: "",
+      result: step.userSubmittedResult ?? "",
     })) ?? [];
 
   return (
@@ -266,16 +209,16 @@ export default function UploadCompletePage() {
               fontWeight="bold"
               lineHeight="1.4"
             >
-              과제 압축 완료!
+              과제 수행 완료!
               <br />
-              고생하셨습니다.
+              고생하셨습니다
             </Text>
             <Text
               color="neutral.600"
               fontSize={{ base: "sm", md: "lg" }}
               fontWeight="medium"
             >
-              성공적으로 로드맵을 완주했어요.
+              성공적으로 로드맵을 완성했어요.
             </Text>
           </VStack>
         </Flex>

--- a/src/pages/upload/_complete/UploadCompletePage.tsx
+++ b/src/pages/upload/_complete/UploadCompletePage.tsx
@@ -302,14 +302,14 @@ export default function UploadCompletePage() {
           </VStack>
         </VStack>
 
-        <Flex justify="center" mt={4}>
+        <Flex justify="center" mt={{ base: 2, md: 4 }}>
           <Button
             bg="seed"
             borderRadius="2xl"
             color="white"
-            fontSize="lg"
+            fontSize={{ base: "md", md: "lg" }}
             fontWeight="bold"
-            h={16}
+            h={{ base: 12, md: 16 }}
             maxW="624px"
             onClick={goToMyPage}
             w="full"

--- a/src/pages/upload/_complete/UploadCompletePage.tsx
+++ b/src/pages/upload/_complete/UploadCompletePage.tsx
@@ -3,7 +3,11 @@ import { useNavigate, useParams } from "react-router";
 
 import { Box, Button, Flex, HStack, Text, VStack } from "@chakra-ui/react";
 
-import { PromptCard, useGetProjectDetail } from "@/entities";
+import {
+  PromptCard,
+  ROADMAP_TYPE_LABEL,
+  useGetProjectDetail,
+} from "@/entities";
 import { ROUTE_PATHS, toaster } from "@/shared";
 import { CheckCircleIcon, ChevronRightIcon } from "@/shared/_assets/icons";
 
@@ -240,13 +244,11 @@ export default function UploadCompletePage() {
           >
             <VStack align="flex-start" gap={1}>
               <Box bg="neutral.50" borderRadius="full" px={3} py={1}>
-                <Text
-                  color="neutral.600"
-                  fontSize="xs"
-                  fontWeight="semibold"
-                  textTransform="uppercase"
-                >
-                  Assignment
+                <Text color="neutral.600" fontSize="xs" fontWeight="semibold">
+                  {project
+                    ? (ROADMAP_TYPE_LABEL[project.roadmapType] ??
+                      project.roadmapType)
+                    : ""}
                 </Text>
               </Box>
               <Text

--- a/src/pages/upload/_complete/UploadCompletePage.tsx
+++ b/src/pages/upload/_complete/UploadCompletePage.tsx
@@ -221,10 +221,17 @@ export default function UploadCompletePage() {
       direction="column"
       justify="center"
       minH="100vh"
-      pb="160px"
-      pt="128px"
+      pb={{ base: "96px", md: "160px" }}
+      pt={{ base: "72px", md: "128px" }}
     >
-      <Flex direction="column" gap={8} mx="auto" px={6} w="full" maxW="896px">
+      <Flex
+        direction="column"
+        gap={{ base: 6, md: 8 }}
+        maxW="896px"
+        mx="auto"
+        px={{ base: 4, md: 6 }}
+        w="full"
+      >
         <Flex
           align="center"
           direction="column"

--- a/src/pages/upload/_complete/UploadCompletePage.tsx
+++ b/src/pages/upload/_complete/UploadCompletePage.tsx
@@ -274,12 +274,17 @@ export default function UploadCompletePage() {
           bg="white"
           border="1px solid"
           borderColor="neutral.50"
-          borderRadius="4xl"
+          borderRadius={{ base: "3xl", md: "4xl" }}
           boxShadow="0px 10px 40px -10px rgba(0,0,0,0.05)"
-          mb={4}
-          p="33px"
+          mb={{ base: 2, md: 4 }}
+          p={{ base: 5, md: 8 }}
         >
-          <Flex align="center" justify="space-between">
+          <Flex
+            align={{ base: "flex-start", md: "center" }}
+            direction="row"
+            gap={{ base: 4, md: 0 }}
+            justify="space-between"
+          >
             <VStack align="flex-start" gap={1}>
               <Box bg="neutral.50" borderRadius="full" px={3} py={1}>
                 <Text
@@ -291,25 +296,41 @@ export default function UploadCompletePage() {
                   Assignment
                 </Text>
               </Box>
-              <Text color="neutral.900" fontSize="2xl" fontWeight="bold">
+              <Text
+                color="neutral.900"
+                fontSize={{ base: "xl", md: "2xl" }}
+                fontWeight="bold"
+                lineHeight="1.4"
+              >
                 {project?.title}
               </Text>
-              <Text color="neutral.600" fontSize="sm" fontWeight="medium">
+              <Text
+                color="neutral.600"
+                fontSize={{ base: "xs", md: "sm" }}
+                fontWeight="medium"
+              >
                 {project?.createdAt}
               </Text>
             </VStack>
 
-            <VStack align="center" gap={1}>
+            <VStack align={{ base: "flex-start", md: "center" }} gap={1}>
               <Flex
                 align="center"
                 bg="rgba(152,201,92,0.1)"
                 borderRadius="full"
-                boxSize={12}
+                boxSize={{ base: 10, md: 12 }}
                 justify="center"
               >
-                <CheckCircleIcon boxSize="22px" color="seed" />
+                <CheckCircleIcon
+                  boxSize={{ base: 5, md: "22px" }}
+                  color="seed"
+                />
               </Flex>
-              <Text color="seed" fontSize="xs" fontWeight="bold">
+              <Text
+                color="seed"
+                fontSize={{ base: "2xs", md: "xs" }}
+                fontWeight="bold"
+              >
                 로드맵 완료
               </Text>
             </VStack>

--- a/src/pages/upload/_complete/UploadCompletePage.tsx
+++ b/src/pages/upload/_complete/UploadCompletePage.tsx
@@ -68,26 +68,36 @@ function AssetItem({
         cursor="pointer"
         justify="space-between"
         onClick={() => setOpen((v) => !v)}
-        p={5}
+        p={{ base: 4, md: 5 }}
       >
-        <HStack gap={5}>
+        <HStack gap={{ base: 3, md: 5 }}>
           <Flex
             align="center"
             bg="neutral.50"
             borderRadius="12px"
             flexShrink={0}
-            boxSize={10}
+            boxSize={{ base: 8, md: 10 }}
             justify="center"
           >
-            <Text color="neutral.600" fontSize="sm" fontWeight="bold">
+            <Text
+              color="neutral.600"
+              fontSize={{ base: "xs", md: "sm" }}
+              fontWeight="bold"
+            >
               {asset.id}
             </Text>
           </Flex>
           <VStack align="flex-start" gap={0.5}>
-            <Text color="neutral.900" fontWeight="bold">
+            <Text
+              color="neutral.900"
+              fontSize={{ base: "sm", md: "md" }}
+              fontWeight="bold"
+              lineHeight="1.4"
+              wordBreak="keep-all"
+            >
               {asset.title}
             </Text>
-            <Text color="neutral.600" fontSize="xs">
+            <Text color="neutral.600" fontSize={{ base: "2xs", md: "xs" }}>
               {asset.subtitle}
             </Text>
           </VStack>
@@ -98,7 +108,7 @@ function AssetItem({
             transition: "transform 0.2s",
           }}
         >
-          <ChevronRightIcon boxSize={4} color="neutral.600" />
+          <ChevronRightIcon boxSize={{ base: 3, md: 4 }} color="neutral.600" />
         </Box>
       </Flex>
 

--- a/src/pages/upload/_complete/UploadCompletePage.tsx
+++ b/src/pages/upload/_complete/UploadCompletePage.tsx
@@ -235,24 +235,24 @@ export default function UploadCompletePage() {
         <Flex
           align="center"
           direction="column"
-          gap="14px"
-          pb={10}
+          gap={{ base: 3, md: "14px" }}
+          pb={{ base: 8, md: 10 }}
           textAlign="center"
         >
           <Flex
             align="center"
             bg="rgba(152,201,92,0.1)"
             borderRadius="full"
-            boxSize={20}
+            boxSize={{ base: 16, md: 20 }}
             justify="center"
           >
-            <CheckCircleIcon boxSize={8} color="seed" />
+            <CheckCircleIcon boxSize={{ base: 6, md: 8 }} color="seed" />
           </Flex>
 
-          <VStack gap={2}>
+          <VStack gap={{ base: 1.5, md: 2 }}>
             <Text
               color="neutral.900"
-              fontSize="3xl"
+              fontSize={{ base: "2xl", md: "3xl" }}
               fontWeight="bold"
               lineHeight="1.4"
             >
@@ -260,7 +260,11 @@ export default function UploadCompletePage() {
               <br />
               고생하셨습니다.
             </Text>
-            <Text color="neutral.600" fontSize="lg" fontWeight="medium">
+            <Text
+              color="neutral.600"
+              fontSize={{ base: "sm", md: "lg" }}
+              fontWeight="medium"
+            >
               성공적으로 로드맵을 완주했어요.
             </Text>
           </VStack>


### PR DESCRIPTION
## 📝 요약 (Summary)

- 업로드 완료 페이지가 모바일 화면에서도 자연스럽게 보이도록 정리했습니다.
- 작은 화면에서도 완료 안내, 과제 정보, 생성된 자산, 이동 버튼에 반응형 UI를 적용했습니다.
- 서버에서 주는 `userSubmittedResult`를 완료 페이지에서도 사용자에게 보여주도록 수정했습니다.

## ✅ 주요 변경 사항 (Key Changes)

- 아래 내용들을 모바일 화면에 맞게 조정했습니다.
  - 업로드 완료 페이지 전체 여백과 카드 간격
  - 완료 안내 영역과 과제 요약 카드 스타일
  - 하단 마이페이지로 이동 버튼
- 생성된 자산 영역에서 프롬프트와 작업 결과를 함께 볼 수 있도록 수정했습니다.

## 💻 상세 구현 내용 (Implementation Details)

### 1. 업로드 완료 페이지 바깥 레이아웃 정리
<img width="417" height="1215" alt="image" src="https://github.com/user-attachments/assets/d4abcc92-0654-425c-99f4-240a1c77eeee" />

- 페이지 바깥 여백과 내부 카드 간격을 화면 크기에 따라 다르게 보이도록 수정했습니다.

### 2. 완료 안내 영역 반응형 적용
<img width="415" height="496" alt="image" src="https://github.com/user-attachments/assets/c98ccc61-8eb3-4b1a-96e7-6daf7570ea8a" />

- 완료 아이콘, 제목, 설명 문구 크기를 모바일 기준으로 조정했습니다.
- 완료 안내 영역의 간격도 함께 조정했습니다.

### 3. 과제 요약 카드 정리
<img width="411" height="132" alt="image" src="https://github.com/user-attachments/assets/c49f5f3c-616c-4efb-b4c5-796b036e56ff" />

- 과제 요약 카드의 padding, borderRadius, 내부 간격을 모바일 기준으로 조정했습니다.
- 기존 `Assignment` 문구 대신 실제 과제 유형이 보이도록 변경했습니다.
- 완료 상태 아이콘과 문구도 모바일 화면에 맞게 함께 정리했습니다.

### 4. 생성된 자산 영역 개선
<img width="412" height="601" alt="image" src="https://github.com/user-attachments/assets/4e0a3149-277b-41d3-9102-81c547272b03" />

- 생성된 자산 카드 헤더의 padding, gap, 번호 박스 크기, 글자 크기를 모바일 기준으로 조정했습니다.
- 생성된 프롬프트 영역은 공용 `PromptCard`를 사용하도록 변경했습니다.
- 사용자가 입력한 작업 결과 ui도 함께 추가해줬습니다.

### 5. 하단 이동 버튼 정리
<img width="476" height="147" alt="image" src="https://github.com/user-attachments/assets/7e6ed1ec-6213-4c68-b250-ea4b919db4f4" />

- `마이페이지로 이동` 버튼의 여백, 높이, 글자 크기를 모바일 기준으로 조정했습니다.

## 🚀 트러블 슈팅 (Trouble Shooting)

- 해당 없음

## ⚠️ 알려진 이슈 및 참고 사항 (Known Issues & Notes)

- 다음 이슈에서 해당 페이지 리펙토링 진행하겠습니다.

## 📸 스크린샷 (Screenshots)
<img width="403" height="1538" alt="image" src="https://github.com/user-attachments/assets/c65c7cf2-5598-418d-b30a-921481efa200" />

<img width="405" height="1377" alt="image" src="https://github.com/user-attachments/assets/51e88a5a-bee3-4d12-8fe2-f82d90f29a35" />


## #️⃣ 관련 이슈 (Related Issues)

- #77
