### PR TITLE
[PR] 마이페이지(MyPage)와 상세 페이지(ProjectDetailPage) 모바일 반응형 UI 설정 추가

### DIFF
--- a/src/entities/project/ui/project-list/ProjectListItem.tsx
+++ b/src/entities/project/ui/project-list/ProjectListItem.tsx
@@ -32,7 +32,7 @@ export const ProjectListItem = ({
       borderColor="container.border"
       borderRadius="2xl"
       boxShadow="0px 8px 30px 0px rgba(0,0,0,0.04)"
-      p="25px"
+      p={{ base: 4, md: "25px" }}
       w="full"
       align="center"
       justify="space-between"
@@ -41,31 +41,37 @@ export const ProjectListItem = ({
       transition="background 0.15s"
       onClick={onClick}
     >
-      <Flex gap={5} align="center">
+      <Flex align="center" gap={{ base: 3, md: 5 }} minW={0}>
         <Flex
           bg={status === "COMPLETED" ? "seed.subtle" : "progress.subtle"}
           borderRadius="xl"
-          boxSize={12}
+          boxSize={{ base: 10, md: 12 }}
           align="center"
           justify="center"
           flexShrink={0}
         >
           <Icon
             color={status === "COMPLETED" ? "seed" : "progress"}
-            w={4}
-            h={5}
+            w={{ base: 3.5, md: 4 }}
+            h={{ base: 4.5, md: 5 }}
           />
         </Flex>
-        <Flex flexDir="column" align="flex-start">
-          <Text color="text" fontSize="lg" fontWeight="bold">
+        <Flex align="flex-start" flexDir="column" minW={0}>
+          <Text
+            color="text"
+            fontSize={{ base: "md", md: "lg" }}
+            fontWeight="bold"
+            lineHeight="1.4"
+            wordBreak="keep-all"
+          >
             {name}
           </Text>
-          <Text color="text.secondary" fontSize="xs">
+          <Text color="text.secondary" fontSize={{ base: "2xs", md: "xs" }}>
             {formatUpdatedAt(updatedAt)}
           </Text>
         </Flex>
       </Flex>
-      <Flex gap={3} align="center">
+      <Flex align="center" gap={{ base: 2, md: 3 }}>
         {onDelete && (
           <IconButton
             aria-label="프로젝트 삭제"
@@ -78,10 +84,14 @@ export const ProjectListItem = ({
               onDelete();
             }}
           >
-            <DeleteIcon color="neutral.400" boxSize={4} />
+            <DeleteIcon color="neutral.400" boxSize={{ base: 3.5, md: 4 }} />
           </IconButton>
         )}
-        <ChevronRightIcon color="neutral.600" w="7px" h="11px" />
+        <ChevronRightIcon
+          color="neutral.600"
+          w={{ base: "6px", md: "7px" }}
+          h={{ base: "10px", md: "11px" }}
+        />
       </Flex>
     </Flex>
   );

--- a/src/entities/project/ui/project-list/ProjectListItem.tsx
+++ b/src/entities/project/ui/project-list/ProjectListItem.tsx
@@ -41,7 +41,7 @@ export const ProjectListItem = ({
       transition="background 0.15s"
       onClick={onClick}
     >
-      <Flex align="center" gap={{ base: 3, md: 5 }} minW={0}>
+      <Flex align="center" flex={1} gap={{ base: 3, md: 5 }} minW={0}>
         <Flex
           bg={status === "COMPLETED" ? "seed.subtle" : "progress.subtle"}
           borderRadius="xl"
@@ -62,7 +62,10 @@ export const ProjectListItem = ({
             fontSize={{ base: "md", md: "lg" }}
             fontWeight="bold"
             lineHeight="1.4"
-            wordBreak="keep-all"
+            overflow="hidden"
+            textOverflow="ellipsis"
+            whiteSpace="nowrap"
+            w="full"
           >
             {name}
           </Text>
@@ -71,7 +74,7 @@ export const ProjectListItem = ({
           </Text>
         </Flex>
       </Flex>
-      <Flex align="center" gap={{ base: 2, md: 3 }}>
+      <Flex align="center" flexShrink={0} gap={{ base: 2, md: 3 }}>
         {onDelete && (
           <IconButton
             aria-label="프로젝트 삭제"

--- a/src/features/mypage/components/features/project-list/ProjectListToolbar.tsx
+++ b/src/features/mypage/components/features/project-list/ProjectListToolbar.tsx
@@ -15,7 +15,12 @@ type Props = {
 
 export const ProjectListToolbar = ({ activeFilter, onFilterChange }: Props) => {
   return (
-    <HStack gap={6} borderBottom="1px solid" borderColor="transparent" pb="1px">
+    <HStack
+      borderBottom="1px solid"
+      borderColor="transparent"
+      gap={{ base: 4, md: 6 }}
+      pb="1px"
+    >
       {FILTER_TABS.map((tab) => {
         const isActive = activeFilter === tab.value;
         return (

--- a/src/features/mypage/ui/section/ProjectListSection.tsx
+++ b/src/features/mypage/ui/section/ProjectListSection.tsx
@@ -46,8 +46,20 @@ export const ProjectListSection = () => {
   const isInitialLoading = isLoading && projects.length === 0;
 
   return (
-    <VStack gap={6} align="flex-start" pt={4} w="full">
-      <Flex w="full" align="center" justify="space-between" px={2}>
+    <VStack
+      align="flex-start"
+      gap={{ base: 4, md: 6 }}
+      pt={{ base: 2, md: 4 }}
+      w="full"
+    >
+      <Flex
+        align={{ base: "flex-start", md: "center" }}
+        direction={{ base: "column", md: "row" }}
+        gap={{ base: 3, md: 0 }}
+        justify="space-between"
+        px={2}
+        w="full"
+      >
         <Text color="text" fontSize="xl" fontWeight="bold">
           내 프로젝트 목록
         </Text>

--- a/src/features/mypage/ui/section/ProjectListSection.tsx
+++ b/src/features/mypage/ui/section/ProjectListSection.tsx
@@ -143,23 +143,23 @@ export const ProjectListSection = () => {
           borderColor="container.border.dashed"
           borderRadius="2xl"
           boxShadow="0px 8px 30px 0px rgba(0,0,0,0.04)"
-          h={24}
-          w="full"
           align="center"
-          justify="center"
           cursor="pointer"
+          h={{ base: 20, md: 24 }}
+          justify="center"
           _hover={{ bg: "neutral.50" }}
-          transition="background 0.15s"
           onClick={() => navigate(ROUTE_PATHS.FILE_UPLOAD)}
+          transition="background 0.15s"
+          w="full"
         >
           <Flex
+            align="center"
             bg="seed.subtle"
             borderRadius="full"
-            boxSize={10}
-            align="center"
+            boxSize={{ base: 9, md: 10 }}
             justify="center"
           >
-            <PlusIcon color="seed" boxSize={4.5} />
+            <PlusIcon color="seed" boxSize={{ base: 4, md: 4.5 }} />
           </Flex>
         </Flex>
       </VStack>

--- a/src/features/mypage/ui/section/UserNameSection.tsx
+++ b/src/features/mypage/ui/section/UserNameSection.tsx
@@ -8,11 +8,24 @@ export const UserNameSection = () => {
   });
 
   return (
-    <VStack align="flex-start" gap={3} px={2} pb={10}>
-      <Text color="text" fontSize="4xl" fontWeight="bold">
+    <VStack
+      align="flex-start"
+      gap={{ base: 2, md: 3 }}
+      px={2}
+      pb={{ base: 8, md: 10 }}
+    >
+      <Text
+        color="text"
+        fontSize={{ base: "2xl", md: "4xl" }}
+        fontWeight="bold"
+      >
         반가워요, {nickname ? `${nickname}님` : <Skeleton h={9} w="120px" />}
       </Text>
-      <Text color="text.secondary" fontSize="lg" fontWeight="medium">
+      <Text
+        color="text.secondary"
+        fontSize={{ base: "sm", md: "lg" }}
+        fontWeight="medium"
+      >
         오늘도 새로운 아이디어를 실현해보세요.
       </Text>
     </VStack>

--- a/src/features/project-detail/ui/ProjectDetailSection.tsx
+++ b/src/features/project-detail/ui/ProjectDetailSection.tsx
@@ -27,11 +27,11 @@ export const ProjectDetailSection = ({ project }: Props) => {
       align="flex-start"
       bg="white"
       border="1px solid white"
-      borderRadius="4xl"
+      borderRadius={{ base: "3xl", md: "4xl" }}
       boxShadow="0px 20px 60px -10px rgba(0,0,0,0.08)"
-      gap={12}
+      gap={{ base: 8, md: 12 }}
       overflow="hidden"
-      p={12}
+      p={{ base: 4, md: 12 }}
       w="full"
     >
       {stepResponses.map((step, i) => {
@@ -39,14 +39,19 @@ export const ProjectDetailSection = ({ project }: Props) => {
         const resultKey = `result-${step.stepCode}`;
 
         return (
-          <VStack align="flex-start" gap={6} key={step.stepCode} w="full">
-            <VStack align="flex-start" gap="10px" w="full">
+          <VStack
+            align="flex-start"
+            gap={{ base: 4, md: 6 }}
+            key={step.stepCode}
+            w="full"
+          >
+            <VStack align="flex-start" gap={{ base: 2, md: "10px" }} w="full">
               <Text color="seed" fontSize="xs" fontWeight="bold">
                 Step {i + 1}
               </Text>
               <Text
                 color="neutral.900"
-                fontSize="26px"
+                fontSize={{ base: "xl", md: "26px" }}
                 fontWeight="bold"
                 lineHeight="1.4"
               >

--- a/src/features/project-detail/ui/ProjectDetailSection.tsx
+++ b/src/features/project-detail/ui/ProjectDetailSection.tsx
@@ -45,7 +45,7 @@ export const ProjectDetailSection = ({ project }: Props) => {
             key={step.stepCode}
             w="full"
           >
-            <VStack align="flex-start" gap={{ base: 2, md: "10px" }} w="full">
+            <VStack align="flex-start" gap={{ base: 2, md: 2.5 }} w="full">
               <Text color="seed" fontSize="xs" fontWeight="bold">
                 Step {i + 1}
               </Text>

--- a/src/pages/mypage/MyPage.tsx
+++ b/src/pages/mypage/MyPage.tsx
@@ -5,7 +5,13 @@ import { ProjectListSection, UserNameSection } from "@/features";
 export default function MyPage() {
   return (
     <Flex align="center" bg="container.bg" direction="column" minH="100vh">
-      <Flex direction="column" maxW="1024px" w="full" py={16} px={6}>
+      <Flex
+        direction="column"
+        maxW="1024px"
+        px={{ base: 4, md: 6 }}
+        py={{ base: 10, md: 16 }}
+        w="full"
+      >
         <UserNameSection />
         <ProjectListSection />
       </Flex>

--- a/src/pages/project-detail/ProjectDetailPage.tsx
+++ b/src/pages/project-detail/ProjectDetailPage.tsx
@@ -12,13 +12,26 @@ export default function ProjectDetailPage() {
   const { data: project, isLoading } = useGetProjectDetail(projectId ?? "");
 
   return (
-    <Flex bg="white" direction="column" minH="100vh" pb="127px" pt="80px">
-      <Flex direction="column" gap={10} mx="auto" px={6} w="full" maxW="896px">
-        <VStack align="flex-start" gap={6}>
+    <Flex
+      bg="white"
+      direction="column"
+      minH="100vh"
+      pb={{ base: "72px", md: "127px" }}
+      pt={{ base: 6, md: "80px" }}
+    >
+      <Flex
+        direction="column"
+        gap={{ base: 6, md: 10 }}
+        maxW="896px"
+        mx="auto"
+        px={{ base: 4, md: 6 }}
+        w="full"
+      >
+        <VStack align="flex-start" gap={{ base: 4, md: 6 }}>
           <Button
             alignSelf="flex-start"
             color="neutral.600"
-            fontSize="sm"
+            fontSize={{ base: "xs", md: "sm" }}
             fontWeight="medium"
             gap={1}
             onClick={() => navigate(ROUTE_PATHS.MYPAGE)}
@@ -36,23 +49,23 @@ export default function ProjectDetailPage() {
             </Flex>
           ) : project ? (
             <>
-              <VStack align="flex-start" gap={2}>
+              <VStack align="flex-start" gap={{ base: 1.5, md: 2 }}>
                 <Box
                   bg="neutral.50"
                   border="1px solid white"
                   borderRadius="md"
                   color="neutral.600"
-                  fontSize="10px"
+                  fontSize={{ base: "2xs", md: "10px" }}
                   fontWeight="regular"
-                  px="9px"
-                  py="5px"
+                  px={{ base: 2, md: "9px" }}
+                  py={{ base: 1, md: "5px" }}
                 >
                   {ROADMAP_TYPE_LABEL[project.roadmapType] ??
                     project.roadmapType}
                 </Box>
                 <Text
                   color="neutral.900"
-                  fontSize="3xl"
+                  fontSize={{ base: "2xl", md: "3xl" }}
                   fontWeight="bold"
                   lineHeight="1.4"
                 >

--- a/src/pages/project-detail/ProjectDetailPage.tsx
+++ b/src/pages/project-detail/ProjectDetailPage.tsx
@@ -17,7 +17,7 @@ export default function ProjectDetailPage() {
       direction="column"
       minH="100vh"
       pb={{ base: "72px", md: "127px" }}
-      pt={{ base: 6, md: "80px" }}
+      pt={{ base: 10, md: 20 }}
     >
       <Flex
         direction="column"

--- a/src/shared/components/common/Pagination.tsx
+++ b/src/shared/components/common/Pagination.tsx
@@ -29,17 +29,17 @@ export const Pagination = ({
   );
 
   return (
-    <HStack gap={2} justify="center" w="full" pt={4}>
+    <HStack gap={{ base: 1, md: 2 }} justify="center" pt={4} w="full">
       <IconButton
         aria-label="이전 페이지"
         variant="ghost"
         disabled={currentPage === 1}
         borderRadius="lg"
-        boxSize={8}
-        minW={8}
+        boxSize={{ base: 7, md: 8 }}
+        minW={{ base: 7, md: 8 }}
         onClick={() => onPageChange(currentPage - 1)}
       >
-        <ChevronLeftIcon boxSize={2.5} color="text" />
+        <ChevronLeftIcon boxSize={{ base: 2, md: 2.5 }} color="text" />
       </IconButton>
 
       {visiblePages.map((page) => (
@@ -47,7 +47,7 @@ export const Pagination = ({
           key={page}
           align="center"
           justify="center"
-          boxSize={8}
+          boxSize={{ base: 7, md: 8 }}
           borderRadius="lg"
           aria-label={`Page ${page}`}
           bg={currentPage === page ? "button.bg" : "transparent"}
@@ -69,7 +69,7 @@ export const Pagination = ({
                 ? "button.foreground"
                 : "button.foreground.secondary"
             }
-            fontSize="sm"
+            fontSize={{ base: "xs", md: "sm" }}
             fontWeight={currentPage === page ? "semibold" : "medium"}
           >
             {page}
@@ -82,11 +82,11 @@ export const Pagination = ({
         variant="ghost"
         disabled={currentPage === totalPages}
         borderRadius="lg"
-        boxSize={8}
-        minW={8}
+        boxSize={{ base: 7, md: 8 }}
+        minW={{ base: 7, md: 8 }}
         onClick={() => onPageChange(currentPage + 1)}
       >
-        <ChevronRightIcon boxSize={2.5} color="text.DEFAULT" />
+        <ChevronRightIcon boxSize={{ base: 2, md: 2.5 }} color="text.DEFAULT" />
       </IconButton>
     </HStack>
   );


### PR DESCRIPTION
## 📝 요약 (Summary)

- 마이페이지와 과제 상세 페이지가 모바일 화면에서도 자연스럽게 보이도록 정리했습니다.
- 작은 화면에서도 사용자 안내 영역, 프로젝트 목록, 과제 상세 카드 ui에 반응형 UI 설정을 추가했습니다.

## ✅ 주요 변경 사항 (Key Changes)

- 마이페이지의 상단 여백과 사용자 안내 영역을 모바일 화면에 맞게 조정했습니다.
- 프로젝트 목록 헤더, 필터 탭, 리스트 카드, 추가 버튼, 페이지네이션을 모바일 기준으로 정리했습니다.
- 과제 상세 페이지의 상단 여백과 제목 영역, 본문 카드 간격을 모바일에서도 보기 좋게 조정했습니다.

## 💻 상세 구현 내용 (Implementation Details)

### 1. 마이페이지 상단 레이아웃 정리
<img width="426" height="121" alt="image" src="https://github.com/user-attachments/assets/5640a7c5-a19c-4f27-8c9d-3d998a434b8b" />

- 마이페이지 바깥 패딩을 화면 크기에 따라 다르게 보이도록 수정했습니다.
- 사용자 이름과 안내 문구의 글자 크기, 간격, 아래 여백을 모바일 기준으로 조정했습니다.

### 2. 프로젝트 목록 헤더 및 필터 영역 반응형 적용
<img width="426" height="89" alt="image" src="https://github.com/user-attachments/assets/91945c3c-ad8c-4c55-90d3-0ab51cff2eb9" />

- 프로젝트 목록 헤더를 모바일에서는 위아래 배치, 큰 화면에서는 기존 가로 배치로 정리했습니다.
- 필터 탭 간격을 모바일 기준으로 줄였습니다.

### 3. 프로젝트 목록 카드 및 하단 영역 개선
<img width="420" height="448" alt="image" src="https://github.com/user-attachments/assets/bee01f7f-f164-42df-8eb7-21abd1d8c7a9" />

- 프로젝트 목록 카드의 padding, gap, 아이콘 크기, 제목/날짜 글자 크기를 모바일 기준으로 조정했습니다.
- 하단 프로젝트 추가 버튼의 높이와 아이콘 크기를 줄였습니다.
- 페이지네이션 버튼 크기, 숫자 폰트, 화살표 크기도 모바일 기준으로 정리했습니다.

### 4. 과제 상세 페이지 상단 반응형 적용
<img width="414" height="173" alt="image" src="https://github.com/user-attachments/assets/446a4456-41e7-4e13-bc12-1aa028200add" />

- 과제 상세 페이지 바깥 패딩과 간격을 모바일 기준으로 조정했습니다.
- 뒤로가기 버튼, 과제 유형 배지, 프로젝트 제목 크기도 함께 정리했습니다.

### 5. 과제 상세 페이지 본문 카드 정리
<img width="423" height="550" alt="image" src="https://github.com/user-attachments/assets/1599aa6e-57d1-4013-8e35-95da809aee5e" />

- 본문 카드의 padding, gap, borderRadius를 모바일 기준으로 줄였습니다.
- 각 step 제목 구간의 간격과 제목 글자 크기도 모바일 화면에 맞게 조정했습니다.
- 내부 `PromptCard`는 기존 반응형 구조를 그대로 사용하도록 유지했습니다.

## 🚀 트러블 슈팅 (Trouble Shooting)

- 해당 없음

## ⚠️ 알려진 이슈 및 참고 사항 (Known Issues & Notes)

- 해당 없음

## 📸 스크린샷 (Screenshots)

<img width="417" height="1165" alt="image" src="https://github.com/user-attachments/assets/f1301da6-0202-4717-afea-2255920eeffb" />

<img width="413" height="1595" alt="image" src="https://github.com/user-attachments/assets/f08ba1a9-c648-4d26-ad36-12625d31817c" />

## #️⃣ 관련 이슈 (Related Issues)

- #79 
